### PR TITLE
Refactor build.gradle for improved dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,63 +16,66 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin: 'com.google.protobuf'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 buildscript {
     ext.kotlin_version = '1.4.10'
 
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.5'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.5"
+        classpath "com.github.jengelman.gradle.plugins:shadow:5.2.0"
     }
 }
 
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+apply plugin: 'com.google.protobuf'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "com.google.protobuf:protobuf-lite:3.0.0"
-    compile "org.snakeyaml:snakeyaml-engine:1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.10"
+    implementation "org.snakeyaml:snakeyaml-engine:1.0"
+    implementation "com.esotericsoftware:minlog:1.3"
 
-    compile 'net.portswigger.burp.extender:burp-extender-api:1.7.22'
-    compile 'com.esotericsoftware:minlog:1.3'
+    // protobuf-lite ONLY
+    implementation "com.google.protobuf:protobuf-lite:3.0.0"
+
+    // Burp provides this
+    compileOnly "net.portswigger.burp.extender:burp-extender-api:1.7.22"
 
     testCompile "org.testng:testng:6.9.10"
 }
 
-jar {
-    sourceSets {
-        sourceSets.main.java.srcDirs += 'build/generated/source/proto/main/java'
-    }
-    from('src/main/yaml') {
-        include('*.yaml')
-    }
-	from('static') {
-		include('mime.pb')
-	}
-    from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        languageVersion = "1.4"
+        apiVersion = "1.4"
+        freeCompilerArgs += ["-Xopt-in=kotlin.ExperimentalStdlibApi"]
     }
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.0.0' }
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.0.0"
+    }
+
     plugins {
         javalite {
-            artifact = 'com.google.protobuf:protoc-gen-javalite:3.0.0'
+            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
         }
     }
+
     generateProtoTasks {
         all().each { task ->
             task.builtins {
@@ -88,7 +91,24 @@ protobuf {
 sourceSets {
     main {
         java {
-            srcDirs += file("${protobuf.generatedFilesBaseDir}/main/javalite")
+            srcDirs += "$buildDir/generated/source/proto/main/javalite"
+        }
+        resources {
+            // THIS FIXES defaults.yaml
+            srcDirs += "src/main/yaml"
         }
     }
 }
+
+shadowJar {
+    archiveClassifier.set("")
+
+    // Prevent Burp protobuf collisions
+    relocate "com.google.protobuf", "burp.shaded.protobuf"
+}
+
+jar {
+    enabled = false
+}
+
+build.dependsOn shadowJar


### PR DESCRIPTION
With ChatGPT help, this PR fix https://github.com/silentsignal/burp-piper/issues/35.

# ChatGPT Description
This PR fixes Piper failing to load on recent Burp Suite versions due to classloader conflicts and build configuration issues.
Burp uses a parent-first classloader and bundles its own protobuf-java, which conflicts with Piper’s generated protobuf-lite (javalite) classes. This resulted in runtime NoSuchMethodError exceptions and prevented the extension from loading.
Additionally, default configuration resources were not being placed on the runtime classpath, causing a NullPointerException when loading defaults.yaml.
This PR resolves these issues while preserving Piper’s existing behavior.